### PR TITLE
Compute transactions timestamps

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,32 @@
+from pydantic import BaseModel
+import csv
+from datetime import datetime
+from transaction import transaction 
+import transaction_timestamp
+import sys
+
+args = sys.argv[1:]
+
+# create a dictionary
+data = {}
+
+if len(args) == 0:
+    raise Exception("You need to specify the file.")
+
+file = args[0]
+print(file)
+with open(file, 'r') as csvf:
+    csvReader = csv.DictReader(csvf)
+         
+    # add each row to the dictionary whose key is the transaction hash
+    for rows in csvReader:
+        tx = transaction(**rows)
+        data[tx.hash] = tx
+
+# date in string format
+latest_block_timestamp = "26.07.2022 12:32:54 AM UTC"
+latest_block_number = 15218113
+transaction_hash = "0x0ba5abf4ef9eedb75a7fd5e645034288e02c6c4fafebf932e191b4df1f8ffac8"
+print(transaction_timestamp.find_transaction_timestamp(transaction_hash, data, latest_block_timestamp, latest_block_number))
+print(transaction_timestamp.find_transaction_timestamp_knowing_average_block_length(transaction_hash, data))
+

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ with open(file, 'r') as csvf:
 # date in string format
 latest_block_timestamp = "26.07.2022 12:32:54 AM UTC"
 latest_block_number = 15218113
-transaction_hash = "0x0ba5abf4ef9eedb75a7fd5e645034288e02c6c4fafebf932e191b4df1f8ffac8"
-print(transaction_timestamp.find_transaction_timestamp(transaction_hash, data, latest_block_timestamp, latest_block_number))
-print(transaction_timestamp.find_transaction_timestamp_knowing_average_block_length(transaction_hash, data))
 
+# Calculate the timestamp for each transaction
+for key in data:
+    print(transaction_timestamp.find_transaction_timestamp(key, data, latest_block_timestamp, latest_block_number))

--- a/test_find_timestamp.py
+++ b/test_find_timestamp.py
@@ -1,0 +1,128 @@
+import pytest
+from transaction import transaction
+import transaction_timestamp
+from datetime import datetime, timedelta
+
+# test to see if the find_transaction_timestamp returns the expected result
+def test_find_transaction_timestamp_returns_value_as_expected():
+	# we create a mock dictionary
+	data_test = {'0x111': transaction(
+		hash='0x111', 
+		nonce=3, 
+		transaction_index='117', 
+		from_address='0x75', 
+		to_address='0x8ed', 
+		value='4000', 
+		gas='21000', 
+		gas_price='23871340807', 
+		input='0x', 
+		receipt_cumulative_gas_used='8784826', 
+		receipt_gas_used='21000', 
+		receipt_contract_address='', 
+		receipt_root='', 
+		receipt_status='1', 
+		block_number=2, 
+		block_hash='0x53c8aa1dc34b7ff5ab4e6df7ba95c9af3c0d72af5cb5a7a241609a3fc806701c', 
+		max_fee_per_gas='43015358335', 
+		max_priority_fee_per_gas='2984641665', 
+		transaction_type='2', 
+		receipt_effective_gas_price='23871340807')}
+
+	last_block_date = "30.07.2015 03:28:23 PM UTC"
+	block_number = 10
+
+	# since we are looking for the timestamp of a transaction from block 2, we calculate the average block length
+	# which is ("30.07.2015 03:28:23 PM UTC" - "30.07.2015 03:26:13 PM UTC")/10 = 2 min and 10 seconds /10= 130 seconds/10 = 13 seconds average block lenght
+	# Since we are looking for the transaction from block 2, "30.07.2015 03:26:13 PM UTC" + 13s * 2 = "30.07.2015 03:26:39 PM UTC"
+	expectedResult = datetime.strptime("30.07.2015 03:26:39 PM UTC", '%d.%m.%Y %I:%M:%S %p %Z')
+	actualResult = transaction_timestamp.find_transaction_timestamp("0x111", data_test, last_block_date, block_number)
+	
+	assert expectedResult == actualResult
+
+# test to see if the find_transaction_timestamp_knowing_average_block_length returns the expected result
+def test_find_transaction_timestamp_knowing_average_block_length_returns_value_as_expected():
+	data_test = {'0x111': transaction(
+		hash='0x111', 
+		nonce=3, 
+		transaction_index='117', 
+		from_address='0x75', 
+		to_address='0x8ed', 
+		value='4000', 
+		gas='21000', 
+		gas_price='23871340807', 
+		input='0x', 
+		receipt_cumulative_gas_used='8784826', 
+		receipt_gas_used='21000', 
+		receipt_contract_address='', 
+		receipt_root='', 
+		receipt_status='1', 
+		block_number=2, 
+		block_hash='0x53c8aa1dc34b7ff5ab4e6df7ba95c9af3c0d72af5cb5a7a241609a3fc806701c', 
+		max_fee_per_gas='43015358335', 
+		max_priority_fee_per_gas='2984641665', 
+		transaction_type='2', 
+		receipt_effective_gas_price='23871340807')}
+
+	# we know that the average block length is 13 since we are using the default value
+	# since we are looking for the transaction from block 2, "30.07.2015 03:26:13 PM UTC" + 13s * 2 = "30.07.2015 03:26:39 PM UTC"
+	expectedResult = datetime.strptime("30.07.2015 03:26:39 PM UTC", '%d.%m.%Y %I:%M:%S %p %Z')
+	resultFindTransactionTimestampKnowingAverage = transaction_timestamp.find_transaction_timestamp_knowing_average_block_length("0x111", data_test)
+	
+	assert resultFindTransactionTimestampKnowingAverage == expectedResult
+
+# find_transaction_timestamp should throw error when the transaction is not present in the dictionary
+def test_find_transaction_timestamp_throws_error_when_transaction_does_not_exist():
+
+	data_test = {'0x111': transaction(
+		hash='0x111', 
+		nonce=3, 
+		transaction_index='117', 
+		from_address='0x75', 
+		to_address='0x8ed', 
+		value='4000', 
+		gas='21000', 
+		gas_price='23871340807', 
+		input='0x', 
+		receipt_cumulative_gas_used='8784826', 
+		receipt_gas_used='21000', 
+		receipt_contract_address='', 
+		receipt_root='', 
+		receipt_status='1', 
+		block_number=2, 
+		block_hash='0x53c8aa1dc34b7ff5ab4e6df7ba95c9af3c0d72af5cb5a7a241609a3fc806701c', 
+		max_fee_per_gas='43015358335', 
+		max_priority_fee_per_gas='2984641665', 
+		transaction_type='2', 
+		receipt_effective_gas_price='23871340807')}
+	
+	with pytest.raises(Exception) as e_info:
+		resultFindTransactionTimestamp = transaction_timestamp.find_transaction_timestamp("0x0", data_test, "any-string", 2)
+	
+# find_transaction_timestamp_knowing_average_block_length should throw error when the transaction is not present in the dictionary
+def test_find_transaction_timestamp_knowing_average_block_length_throws_error_when_transaction_does_not_exist():
+
+	data_test = {'0x111': transaction(
+		hash='0x111', 
+		nonce=3, 
+		transaction_index='117', 
+		from_address='0x75', 
+		to_address='0x8ed', 
+		value='4000', 
+		gas='21000', 
+		gas_price='23871340807', 
+		input='0x', 
+		receipt_cumulative_gas_used='8784826', 
+		receipt_gas_used='21000', 
+		receipt_contract_address='', 
+		receipt_root='', 
+		receipt_status='1', 
+		block_number=2, 
+		block_hash='0x53c8aa1dc34b7ff5ab4e6df7ba95c9af3c0d72af5cb5a7a241609a3fc806701c', 
+		max_fee_per_gas='43015358335', 
+		max_priority_fee_per_gas='2984641665', 
+		transaction_type='2', 
+		receipt_effective_gas_price='23871340807')}
+	
+	with pytest.raises(Exception) as e_info:
+		resultFindTransactionTimestamp = transaction_timestamp.find_transaction_timestamp_knowing_average_block_length("0x0", data_test)
+	

--- a/transaction.py
+++ b/transaction.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+import csv
+from datetime import datetime
+
+class transaction(BaseModel):
+    hash: str
+    nonce: int
+    transaction_index: str
+    from_address: str
+    to_address: str
+    value: str
+    gas: str
+    gas_price: str
+    input: str
+    receipt_cumulative_gas_used: str
+    receipt_gas_used: str
+    receipt_contract_address: str
+    receipt_root: str
+    receipt_status: str
+    block_number: int
+    block_hash: str
+    max_fee_per_gas: str
+    max_priority_fee_per_gas: str
+    transaction_type: str
+    receipt_effective_gas_price: str

--- a/transaction_timestamp.py
+++ b/transaction_timestamp.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timedelta
+
+# default value for the timestamp of the block with number 0 taken from Etherscan
+first_block_timestamp = "30.07.2015 03:26:13 PM UTC"
+
+# default average block length
+average_block_length = 13
+
+# function used to find the timestamp of a transaction without knowing the average block length
+# we need the latest block timestamp and latest block number in order to calculate the average block length
+def find_transaction_timestamp(transaction_hash, dictionary, latest_blob_timestamp, latest_block_number):
+    if not transaction_hash in dictionary:
+        raise Exception("The transaction does not exist in the dataset.")
+
+    transaction = dictionary[transaction_hash]
+
+    t1 = datetime.strptime(first_block_timestamp, '%d.%m.%Y %I:%M:%S %p %Z')
+    t2 = datetime.strptime(latest_blob_timestamp, '%d.%m.%Y %I:%M:%S %p %Z')
+
+    # get difference between timestamp of the latest block and timestamp of the first block
+    delta = t2 - t1
+
+    # find the average block length
+    avg = delta.total_seconds()/latest_block_number
+
+    # calculate the approximate timestamp for the transaction
+    transaction_timestamp = t1 + timedelta(seconds=transaction.block_number * avg)
+
+    return transaction_timestamp
+
+# function used to find the timestamp of a transaction using the default average block length
+def find_transaction_timestamp_knowing_average_block_length(transaction_hash, dictionary):
+    if not transaction_hash in dictionary:
+        raise Exception("The transaction does not exist in the dataset.")
+
+    transaction = dictionary[transaction_hash]
+
+    t1 = datetime.strptime(first_block_timestamp, '%d.%m.%Y %I:%M:%S %p %Z')
+
+    # calculate the approximate timestamp for the transaction
+    transaction_timestamp = t1 + timedelta(seconds=transaction.block_number * average_block_length)
+
+    return transaction_timestamp


### PR DESCRIPTION
**Description:** We read the csv file and store each row as a Transaction object in the dictionary. We use the transaction_hash as a key. We have two functions two compute the transaction timestamp: find_transaction_timestamp (which also calculates the average block length using the genesis block and last block created) and find_transaction_timestamp_knowing_average_block_length (which uses the default average block length of 13 seconds).

**Validation:** 
1. Ran the code locally, compared the result with the Etherscan timestamps. Since we are using an average block length, the timestamps that we obtain are slightly different than the timestamp from Etherscan.
2. Wrote unit tests.