### PR TITLE
Compute the price in usd for gas used

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from transaction import transaction
 import transaction_timestamp
 import sys
 import transaction_gas_cost
+import transaction_gas_dollar_cost
 
 args = sys.argv[1:]
 
@@ -35,3 +36,8 @@ for key in data:
 # calculate the gas cost in gwei for each transaction
 for key in data:
     print(transaction_gas_cost.find_transaction_gas_cost(key, data))
+
+coin_info = transaction_gas_dollar_cost.take_coin_info_from_list("Ethereum")
+# calculate the gas cost in dollars
+for key in data:
+    print(transaction_gas_dollar_cost.find_dollar_cost_of_gas_used(key, data, latest_block_timestamp, latest_block_number, coin_info["id"]))

--- a/test_find_gas_cost_in_dollars.py
+++ b/test_find_gas_cost_in_dollars.py
@@ -1,0 +1,58 @@
+import pytest
+import transaction_gas_dollar_cost
+from transaction import transaction
+import transaction_gas_cost
+
+# test to check if the take_coin_info_from_list returns the expected coin info
+def test_take_coin_info_from_list_returns_value_as_expected():
+    ethereum_info = {
+                        "id": "ethereum",
+                        "symbol": "eth",
+                        "name": "Ethereum"
+                    }
+
+    assert ethereum_info == transaction_gas_dollar_cost.take_coin_info_from_list("Ethereum")
+
+# test to check if the take_coin_info_from_list throws error when the coin does not exist
+def test_take_coin_info_from_list_throws_error_when_coin_name_does_not_exist():
+    with pytest.raises(Exception):
+        transaction_gas_dollar_cost.take_coin_info_from_list("coin-does-not-exist-in-the list")
+
+# test to check if the dollar cost of the gas used is as expected
+def test_find_dollar_cost_of_gas_used_returns_value_as_expected():
+    # we create a mock dictionary
+    data_test = {'0x111': transaction(
+        hash='0x111', 
+        nonce=3, 
+        transaction_index='117', 
+        from_address='0x75', 
+        to_address='0x8ed', 
+        value='4000', 
+        gas='21000', 
+        gas_price='23871340807', 
+        input='0x', 
+        receipt_cumulative_gas_used='8784826', 
+        receipt_gas_used='186594', 
+        receipt_contract_address='', 
+        receipt_root='', 
+        receipt_status='1', 
+        block_number=1, 
+        block_hash='0x53c8aa1dc34b7ff5ab4e6df7ba95c9af3c0d72af5cb5a7a241609a3fc806701c', 
+        max_fee_per_gas='43015358335', 
+        max_priority_fee_per_gas='2984641665', 
+        transaction_type='2', 
+        receipt_effective_gas_price='32035059237')}
+
+    # expected result is taken from Etherscan for the transaction with 0xd6ba7875aac43000e4e1b1b45dabb15e6ddc9b6fe862115f28ae4215c7319b24 hash
+    gas_cost_gwei = 5977549843268778 * transaction_gas_cost.from_wei_to_gwei
+
+    # default value for the timestamp of the block with number 0 taken from Etherscan
+    first_block_timestamp = "30.07.2017 03:26:13 PM UTC"
+    last_block_timestamp = "30.07.2017 03:26:23 PM UTC"
+    last_block_number = 1
+    eth_to_usd_for_timestamp = 197.19896347978235
+    expectedResult = gas_cost_gwei * transaction_gas_dollar_cost.gwei_to_eth * eth_to_usd_for_timestamp
+
+    actualResult = transaction_gas_dollar_cost.find_dollar_cost_of_gas_used('0x111', data_test, last_block_timestamp, last_block_number, "ethereum")
+
+    assert expectedResult == actualResult

--- a/transaction_gas_dollar_cost.py
+++ b/transaction_gas_dollar_cost.py
@@ -1,0 +1,43 @@
+from pycoingecko import CoinGeckoAPI
+import datetime
+import transaction_gas_cost
+import transaction_timestamp
+
+default_currency = "usd"
+gwei_to_eth = 0.00000000185 
+
+# function which returns the coin info knowing the name of the coin from the list of all coins
+def take_coin_info_from_list(coin_name):
+    coin_api = CoinGeckoAPI()
+
+    coin_list = coin_api.get_coins_list()
+
+    coin_info = {'id':"no-coin"}
+    for element in coin_list:
+        if element['name'] == coin_name:
+            coin_info = element
+
+    if coin_info["id"] == "no-coin":
+        raise Exception("No coin with name " + coin_name + " was found in the list.")
+
+    return coin_info
+
+# function which returns the price of the coin with the id taken as parameter in the default currency
+def find_coin_price_in_currency_at_transaction_time(id, transaction_time):
+    coin_api = CoinGeckoAPI()
+
+    time = str(transaction_time.day) + "-" + str(transaction_time.month) + "-" + str(transaction_time.year)
+    history = coin_api.get_coin_history_by_id(id, time)
+
+    return history["market_data"]["current_price"][default_currency]
+
+# function which computes the gas cost in the default currency (usd)
+def find_dollar_cost_of_gas_used(transaction_hash, data, latest_block_timestamp, latest_block_number, coin_id):
+    gas_cost_gwei = transaction_gas_cost.find_transaction_gas_cost(transaction_hash, data)
+    transaction_time = transaction_timestamp.find_transaction_timestamp(transaction_hash, data, latest_block_timestamp, latest_block_number)
+
+    eth_price_in_default_currency = find_coin_price_in_currency_at_transaction_time(coin_id, transaction_time)
+    gas_cost_eth = gas_cost_gwei * gwei_to_eth
+    gas_cost_default_currency = gas_cost_eth * eth_price_in_default_currency
+
+    return gas_cost_default_currency


### PR DESCRIPTION
**Description:** This PR adds support to use CoinGecko API to retrieve the price of ETH in dollars at the timestamp of the transaction and then computes the gas price in dollars.

**Validation:**
1. Ran code locally.
2. Ran unit tests.